### PR TITLE
Update Chernoff bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # README
 
-[![Unitary Fund](https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=for-the-badge)](http://unitary.fund)
+[![Unitary Foundation](https://img.shields.io/badge/Supported%20By-UNITARY%20FOUNDATION-brightgreen.svg?style=for-the-badge)](https://unitary.foundation)
 
 > Program is an embodiment of an algorithm. Algorithms works on information, programs works on data. - Donald Knuth.
 

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -912,8 +912,8 @@ We focus on a restricted class of random variables, i.e. the case when our rando
 :::{.theorem #chernoff-bound name="Chernoff bound"}
 Let $X=\sum_i^n X_i$ where $X_i =1$ with probability $p_i$ and $X_i=0$ with probability $(1-p_i)$, and all $X_i$ are independent. Let $\mu=E[X] = \sum_i^n p_i$. Then:
 
-- *Upper tail*: $P(X \geq (1+\delta)\mu) \leq e^-\frac{\delta^2}{2+\delta}\mu$ for all $\delta > 0$
-- *Lower tail*: $P(X \leq (1-\delta)\mu) \leq e^{\mu\delta^2/2}$ for all $0 \leq \delta \leq 1$
+- *Upper tail*: $P(X \geq (1+\delta)\mu) \leq e^{-\frac{\delta^2}{2+\delta}\mu}$ for all $\delta > 0$
+- *Lower tail*: $P(X \leq (1-\delta)\mu) \leq e^{-\mu\delta^2/2}$ for all $0 < \delta < 1$
 
 :::
 
@@ -974,8 +974,8 @@ You can find a nice proof [here](https://math.mit.edu/~goemans/18310S15/chernoff
 ```{theorem, chernoff-bound2, name="Chernoff bound"}
 Suppose $X_1, \dots, X_t$ are independent random variables taking values in $\{0,1\}$. Let $M_t= (X_1 + \dots X_t)/t$ denote their average value. Then for any $0 < \epsilon < 1$,
 
-- (Multiplicative) $Pr[M_t - \mu \leq -\epsilon \mu] \leq \exp^{-\frac{t\mu\epsilon^2}{2}}$ and $Pr[M_t - \mu \geq \epsilon \mu] \leq \exp^{-\frac{t\mu\epsilon^2}{3}}$
-- (Additive)  $Pr[M_t - \mu \leq -\epsilon ] \leq exp^{-2t\epsilon^2}$ and $Pr[M_t - \mu \geq \epsilon ] \leq \exp^{-2t\epsilon^2}$
+- (Multiplicative) $Pr[M_t - \mu \leq -\epsilon \mu] \leq \exp\left(-\frac{t\mu\epsilon^2}{2}\right)$ and $Pr[M_t - \mu \geq \epsilon \mu] \leq \exp\left(-\frac{t\mu\epsilon^2}{3}\right)$
+- (Additive)  $Pr[M_t - \mu \leq -\epsilon ] \leq exp\left(-2t\epsilon^2\right)$ and $Pr[M_t - \mu \geq \epsilon ] \leq \exp\left(-2t\epsilon^2\right)$
 
 ```
 


### PR DESCRIPTION
Noticed some formatting issues when going through the [Chernoff bound section](https://quantumalgorithms.org/probability.html#concentration-inequalities). Updated the latex, and while doing so found a missing minus sign in the lower tail equation (at least according to the first linked reference https://math.mit.edu/~goemans/18310S15/chernoff-notes.pdf).

While here, I updated the UF badge on the readme :)