### PR TITLE
Keep browser back navigation anchored after hash jumps

### DIFF
--- a/header.html
+++ b/header.html
@@ -9,6 +9,73 @@
 </script>
 <link rel="shortcut icon" href="favicon/favicon.ico" />
 
+<script>
+  (function () {
+    if (!("history" in window) || !("sessionStorage" in window)) {
+      return;
+    }
+
+    var scrollKey = "qa:last-scroll:" + location.pathname;
+    var restoring = false;
+
+    function rememberScroll() {
+      if (restoring) {
+        return;
+      }
+      sessionStorage.setItem(scrollKey, String(window.scrollY || window.pageYOffset || 0));
+    }
+
+    function restoreScroll() {
+      var savedY = Number(sessionStorage.getItem(scrollKey));
+      if (!Number.isFinite(savedY)) {
+        return;
+      }
+
+      restoring = true;
+      if ("scrollRestoration" in history) {
+        history.scrollRestoration = "manual";
+      }
+
+      var attempts = 0;
+      function retryAfterLayoutSettles() {
+        window.scrollTo(0, savedY);
+        attempts += 1;
+        if (attempts < 8 && Math.abs((window.scrollY || window.pageYOffset || 0) - savedY) > 4) {
+          window.setTimeout(retryAfterLayoutSettles, 100);
+          return;
+        }
+        restoring = false;
+      }
+
+      window.setTimeout(retryAfterLayoutSettles, 0);
+      window.setTimeout(retryAfterLayoutSettles, 250);
+    }
+
+    document.addEventListener("click", function (event) {
+      var link = event.target.closest && event.target.closest("a[href]");
+      if (!link) {
+        return;
+      }
+
+      var target = new URL(link.href, location.href);
+      if (target.pathname === location.pathname && target.hash && target.hash !== location.hash) {
+        rememberScroll();
+      }
+    });
+
+    window.addEventListener("popstate", restoreScroll);
+    window.addEventListener("pageshow", function (event) {
+      if (event.persisted) {
+        restoreScroll();
+      }
+    });
+
+    if ("scrollRestoration" in history) {
+      history.scrollRestoration = "auto";
+    }
+  })();
+</script>
+
 
 
 <!-- Google Tag Manager -->


### PR DESCRIPTION
# PR draft: Fix Safari back button scroll restoration after reference jumps

Closes https://github.com/Scinawa/quantumalgorithms.org/issues/72

## Summary

This adds a small, dependency-free scroll restoration helper to `header.html`.

When a reader clicks an in-page reference link, the script stores the current scroll position for the current page. If the browser later navigates back via history or restores the page from the back-forward cache, it restores that saved position after layout has had a chance to settle.

## Why

Safari can lose the expected scroll position after jumping from a deep section to an appendix/reference anchor and then pressing Back. The page also has delayed layout work from rendered math/content, so a single immediate `scrollTo` is not always enough. The helper retries briefly and then stops.

## Scope

- Does not change book content.
- Does not change styles.
- Does not add dependencies.
- Only runs for same-page hash links and browser history/page-cache restoration.

## Verification

- Extracted the injected JavaScript from `header.html` and ran `node --check` successfully.
- Reviewed the diff to confirm the change is limited to `header.html`.

## Not tested

- Manual Safari reproduction, because Safari is not available in this Windows environment.
